### PR TITLE
Update the karma adapter to work with newer versions of Chai

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for [Karma](http://karma-runner.github.io)
 Requirements
 ------------
 
-This Karma plugin requires Karma `>=0.10`
+This Karma plugin requires Karma `>=0.10` and Chai `>=2.0`.
 
 Installation
 ------------

--- a/index.js
+++ b/index.js
@@ -1,13 +1,25 @@
 var path = require('path');
+var _ = require('lodash');
 
-var pattern = function(file) {
+var pattern = function (file) {
   return {pattern: file, included: true, served: true, watched: false};
 };
 
+var endsWith = function(substr) {
+  return function(str) {
+    return str.indexOf(substr) === (str.length - substr.length);
+  };
+};
+
 var framework = function(files) {
-  files.unshift(pattern(path.resolve(require.resolve('dirty-chai'))));
-  files.unshift(pattern(path.resolve(require.resolve('chai'), '../chai.js')));
+  var chaiPath = path.resolve(require.resolve('chai'), '../chai.js');
+  if (!_(files).map('pattern').find(endsWith(path.relative(__dirname, chaiPath)))) {
+    files.unshift(pattern(chaiPath));
+  }
+
+  files.push(pattern(path.resolve(require.resolve('dirty-chai'))));
 };
 
 framework.$inject = ['config.files'];
+
 module.exports = {'framework:dirty-chai': ['factory', framework]};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-dirty-chai",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Karma adapter for the dirty-chai plugin",
   "main": "index.js",
   "repository": {
@@ -19,10 +19,11 @@
   },
   "homepage": "https://github.com/prodatakey/karma-dirty-chai",
   "peerDependencies": {
-    "karma": ">=0.10"
+    "karma": ">=0.10",
+    "chai": ">=2.0"
   },
   "dependencies": {
-    "chai": "<1.10.0",
-    "dirty-chai": "0.0.1"
+    "dirty-chai": "1.1.0",
+    "lodash": "^3.3.1"
   }
 }


### PR DESCRIPTION
We needed this to work with Chai `>=2.0`, so we made a few changes in the resolving of the Chai package. We also turned the Chai dependency into a peer dependency to make stuff visibly break when incompatible.

Note: This probably breaks the package for old versions of Chai, so take care if you decide to merge :)

Full changelog:
- Turn chai into a peer dependency, and require it to be `>=2.0`.
- Update dirty-chai.
- Utilize different resolve technique, introduce dependency on lodash.
- Bump version.
