### PR TITLE
Updating dirty-chai to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "chai": "<1.10.0",
-    "dirty-chai": "0.0.1"
+    "dirty-chai": "1.2.1"
   }
 }


### PR DESCRIPTION
Howdy!

Dirty-chai has been updated since 0.0.1 and it may be time to update. This is still a "hard" lock-in version, maybe this should consider a loser version definition so it updates automatically in the future? 
