### PR TITLE
fix for karma 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Install the module via npm
 $ npm install --save-dev karma-dirty-chai
 ```
 
-Add `dirty-chai` to the `frameworks` key in your Karma configuration:
+Add `dirty-chai` to the `frameworks` key in your Karma configuration before `'chai'`:
 
 ```js
 module.exports = function(config) {
   'use strict';
   config.set({
-    frameworks: ['mocha', 'dirty-chai'],
+    frameworks: ['mocha', 'dirty-chai', 'chai'],
     #...
   });
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var pattern = function(file) {
 
 var framework = function(files) {
   files.unshift(pattern(path.resolve(require.resolve('dirty-chai'))));
-  files.unshift(pattern(path.resolve(require.resolve('chai'), '../chai.js')));
 };
 
 framework.$inject = ['config.files'];


### PR DESCRIPTION
With karma 1.x the automatic inclusion of chai by karma-dirty-chai somehow breaks the listing of js files which karma includes in html. If I manually include chai in the list of frameworks everything seems to work in both karma 1.x and 0.x
