### PR TITLE
Support chai 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/prodatakey/karma-dirty-chai",
   "peerDependencies": {
     "karma": ">=0.10",
-    "chai": "<1.10.0 || >1.10.0 <4",
+    "chai": "<1.10.0 || >1.10.0 <5",
     "dirty-chai": "^2.0.1"
   }
 }


### PR DESCRIPTION
dirty-chai already supports chai 4.x

I have tested this locally and it works without issues.