### PR TITLE
Update to support newest version of chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/prodatakey/karma-dirty-chai",
   "peerDependencies": {
     "karma": ">=0.10",
-    "chai": "<1.10.0 || >1.10.0 <4",
+    "chai": "<1.10.0 || >1.10.0 <5",
     "dirty-chai": "^2.0.1"
   }
 }


### PR DESCRIPTION
@joshperry I've been using karma-dirty-chai extensively with the newest version of chai (4.1.2), which dirty-chai [already supports](https://github.com/prodatakey/dirty-chai/blob/53a0def42c752c044c78b5544ba69de75231c44f/package.json#L40) as well.  No issues thus far.

Can you please merge this and publish a patch version (or however you prefer) so that I can stop getting yarn/npm warnings about peer dependency mismatches?  Thank you!